### PR TITLE
fix: NOVADEV-636

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ pnpm-lock.yaml
 # vercel
 .vercel
 tsconfig.tsbuildinfo
+
+.vercel

--- a/components/AutoCompleteSingle/AutoCompleteSingle.tsx
+++ b/components/AutoCompleteSingle/AutoCompleteSingle.tsx
@@ -13,8 +13,12 @@ const AutoCompleteSingle: React.FC<AmpSDKProps> = ({ ampSDK }) => {
       sx={{ width: '100%', marginTop: '6px' }}
       value={value}
       onChange={(event, val) => {
-        ampSDK.setValue({...val, name: val.name.replace(/\(.*\)\s/, '')})
-        setValue(val)
+        if(val !== null){
+          ampSDK.setValue({...val, name: val.name.replace(/\(.*\)\s/, '')})
+          setValue(val)
+        }else{
+          ampSDK.clearValue()
+        }
       }}
       onClose={() => {
         ampSDK.setHeight(70)
@@ -22,7 +26,6 @@ const AutoCompleteSingle: React.FC<AmpSDKProps> = ({ ampSDK }) => {
       onOpen={() => {
         ampSDK.setHeight(540)
       }}
-      onEmptied={ampSDK.clearValue}
       renderInput={(params) => <TextField {...params} label={ampSDK.label} />}
     />
   )


### PR DESCRIPTION
- autoCompleteSingle onChange must test for nul val and run ampSDK.clearValue() if true
- also ignore .vercel folder (created when testing)