### PR TITLE
feat!: page cache fix, prefer cors for requests, add bigcommerce-cors docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ We would reccomend that you build and host your own version of the extension so 
 
 Instructions for basic registration & setup of the ecomm-toolkit in your Amplience Dynamic Content box [are here](./docs/extension.md). Then come back to the Snippets section below.
 
+Most backends will require you to add the extension URL (self-hosted, localhost or otherwise) to their CORS allowed origins list to allow requests. See the commerce platform documentation above for more information on what needs to be done and available features.
+
+If you're hosting the extension yourself and want to use features that are not allowed by CORS versions of vendor APIs, you can define the environment variable `INTEGRATION_MIDDLEWARE_SERVER=1` to allow the next server to host the middleware proxy, which should allow use of any API. This will also switch builds of the extension to attempt to use the middleware API by default instead of making CORS requests.
+
+`middleware_api` can be provided on the extension config to use any middleware API server regardless of environment variable.
+
 ## 🧩 Extension Snippets
 
 Since the eComm Toolkit requires a number of "Instance Parameters", we recommend providing a number of extension snippets for ease of use and to ensure functionality. By including Snippets in an extension registration, you'll be able to quickly configure properties when you're editing/creating a Content Schema that are automatically associated with an extension.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 
 #### ⚙️ Features
 
+-   Product Finder
 -   Category selector
 -   User Segment selector
--   Product Finder
 
 ## 🏁 Quickstart
 

--- a/components/ProductSelector/index.tsx
+++ b/components/ProductSelector/index.tsx
@@ -23,6 +23,7 @@ import { AmpSDKProps } from '../../lib/models/treeItemData'
 import { isEqual } from 'lodash'
 
 import { PageCache, Product } from '@amplience/dc-integration-middleware'
+import { Utils } from '../../lib/util'
 
 interface TabPanelProps {
     children?: React.ReactNode
@@ -87,6 +88,11 @@ const ProductSelector: React.FC<AmpSDKProps> = ({ ampSDK }) => {
 
     const [requestInfo] = useState({ id: 0 })
 
+    const showError = (error) => {
+        setAlertMessage(Utils.errorToString(error));
+        setShowAlert(true);
+    }
+
     const handlePageChange = (event, value) => {
         setLoadingResults(true)
         setPage(value)
@@ -144,8 +150,7 @@ const ProductSelector: React.FC<AmpSDKProps> = ({ ampSDK }) => {
 
                 setPageWithCache(cache, 1)
             } catch(e) {
-                // TODO: show modal error
-                console.log("ERROR", e)
+                showError(e)
             }
         }
     }
@@ -160,8 +165,7 @@ const ProductSelector: React.FC<AmpSDKProps> = ({ ampSDK }) => {
 
                 setPageWithCache(cache, 1);
             } catch(e) {
-                // TODO: show modal error
-                console.log("ERROR", e) 
+                showError(e) 
             }
         }
     }
@@ -334,8 +338,7 @@ const ProductSelector: React.FC<AmpSDKProps> = ({ ampSDK }) => {
                 })
                 return p.filter((item: any) => item !== null)
             } catch(e) {
-                // TODO: show modal error
-                console.log("ERROR", e)
+                showError(e)
                 return []
             }
         }

--- a/components/ProductSelector/index.tsx
+++ b/components/ProductSelector/index.tsx
@@ -137,7 +137,7 @@ const ProductSelector: React.FC<AmpSDKProps> = ({ ampSDK }) => {
     const searchByCategory = async (category: string) => {
         setResults([])
         if (category !== '') {
-            const cache = new PageCache(ampSDK.commerceApi.getProducts, {
+            const cache = new PageCache<Product>(ampSDK.commerceApi.getProducts.bind(ampSDK.commerceApi), {
                 category
             } as any, itemsPerPage)
 
@@ -148,7 +148,7 @@ const ProductSelector: React.FC<AmpSDKProps> = ({ ampSDK }) => {
     const searchByKeyword = async () => {
         setResults([])
         if (keywordInput.current.value !== '') {
-            const cache = new PageCache(ampSDK.commerceApi.getProducts, {
+            const cache = new PageCache<Product>(ampSDK.commerceApi.getProducts.bind(ampSDK.commerceApi), {
                 keyword: keywordInput.current.value
             } as any, itemsPerPage)
 

--- a/components/ProductSelector/index.tsx
+++ b/components/ProductSelector/index.tsx
@@ -137,22 +137,32 @@ const ProductSelector: React.FC<AmpSDKProps> = ({ ampSDK }) => {
     const searchByCategory = async (category: string) => {
         setResults([])
         if (category !== '') {
-            const cache = new PageCache<Product>(ampSDK.commerceApi.getProducts.bind(ampSDK.commerceApi), {
-                category
-            } as any, itemsPerPage)
+            try {
+                const cache = new PageCache<Product>(ampSDK.commerceApi.getProducts.bind(ampSDK.commerceApi), {
+                    category
+                } as any, itemsPerPage)
 
-            setPageWithCache(cache, 1)
+                setPageWithCache(cache, 1)
+            } catch(e) {
+                // TODO: show modal error
+                console.log("ERROR", e)
+            }
         }
     }
 
     const searchByKeyword = async () => {
         setResults([])
         if (keywordInput.current.value !== '') {
-            const cache = new PageCache<Product>(ampSDK.commerceApi.getProducts.bind(ampSDK.commerceApi), {
-                keyword: keywordInput.current.value
-            } as any, itemsPerPage)
+            try {
+                const cache = new PageCache<Product>(ampSDK.commerceApi.getProducts.bind(ampSDK.commerceApi), {
+                    keyword: keywordInput.current.value
+                } as any, itemsPerPage)
 
-            setPageWithCache(cache, 1);
+                setPageWithCache(cache, 1);
+            } catch(e) {
+                // TODO: show modal error
+                console.log("ERROR", e) 
+            }
         }
     }
 
@@ -318,10 +328,16 @@ const ProductSelector: React.FC<AmpSDKProps> = ({ ampSDK }) => {
             if (ids === '' || ids == null) { 
                 return []
             }
-            const p = await ampSDK.commerceApi.getProducts({
-                productIds: ids
-            })
-            return p.filter((item: any) => item !== null)
+            try { 
+                const p = await ampSDK.commerceApi.getProducts({
+                    productIds: ids
+                })
+                return p.filter((item: any) => item !== null)
+            } catch(e) {
+                // TODO: show modal error
+                console.log("ERROR", e)
+                return []
+            }
         }
         // form comma-delim ID string
         if (storedValue != undefined) {

--- a/components/ProductSelector/index.tsx
+++ b/components/ProductSelector/index.tsx
@@ -389,7 +389,7 @@ const ProductSelector: React.FC<AmpSDKProps> = ({ ampSDK }) => {
         <div ref={container}>
             <Dialog open={showAlert} onClose={() => setShowAlert(false)}>
                 <Card variant='outlined'>
-                    <CardContent>{alertMessage}</CardContent>
+                    <CardContent style={{whiteSpace: "pre-wrap"}}>{alertMessage}</CardContent>
                 </Card>
             </Dialog>
             <Backdrop

--- a/components/multi-select/index.tsx
+++ b/components/multi-select/index.tsx
@@ -28,7 +28,7 @@ function App() {
     if (errorText) {
         component = <Dialog open={true}>
             <Card variant='outlined'>
-                <CardContent>{errorText}</CardContent>
+                <CardContent style={{whiteSpace: "pre-wrap"}}>{errorText}</CardContent>
             </Card>
         </Dialog>
     } else if (ampSDK?.view === 'single') {

--- a/components/multi-select/index.tsx
+++ b/components/multi-select/index.tsx
@@ -16,7 +16,11 @@ function App() {
     const [ampSDK, setAmpSDK] = useState<any>(undefined)
 
     useEffect(() => {
-        amplienceSDK().then(setAmpSDK)
+        try {
+            amplienceSDK().then(setAmpSDK)
+        } catch (e) {
+            console.log("ERROR", e)
+        }
     }, [ampSDK])
 
     let component = <></>

--- a/components/multi-select/index.tsx
+++ b/components/multi-select/index.tsx
@@ -10,22 +10,28 @@ import TreeViewSingle from '../TreeViewSingle/TreeViewSingle'
 import ProductSelector from '../ProductSelector'
 
 import amplienceSDK from '../../lib/sdk'
-import { Typography, Divider } from '@mui/material'
+import { Typography, Divider, Dialog, Card, CardContent } from '@mui/material'
+import { Utils } from '../../lib/util'
 
 function App() {
     const [ampSDK, setAmpSDK] = useState<any>(undefined)
+    const [errorText, setErrorText] = useState<any>(undefined)
 
     useEffect(() => {
-        try {
-            amplienceSDK().then(setAmpSDK)
-        } catch (e) {
-            console.log("ERROR", e)
-        }
+        amplienceSDK().then(setAmpSDK).catch((e) => {
+            setErrorText(Utils.errorToString(e))
+        })
     }, [ampSDK])
 
     let component = <></>
 
-    if (ampSDK?.view === 'single') {
+    if (errorText) {
+        component = <Dialog open={true}>
+            <Card variant='outlined'>
+                <CardContent>{errorText}</CardContent>
+            </Card>
+        </Dialog>
+    } else if (ampSDK?.view === 'single') {
         component = <AutoCompleteSingle ampSDK={ampSDK} />
     } else if (ampSDK?.view === 'multi') {
         component = <AutoCompleteMultiple ampSDK={ampSDK} />

--- a/docs/commerce/bigcommerce-cors.md
+++ b/docs/commerce/bigcommerce-cors.md
@@ -1,0 +1,9 @@
+# BigCommerce
+
+_NOTE: This backend does not support fetching customer groups._
+
+In order to have this extension point to your BigCommerce instance you need specific installation params, instance details and API access. 
+
+[Extension Instalation Params Docs](https://amplience.com/developers/docs/integrations/extensions/register-use/#installation-parameters)
+
+Full details can be seen in the `dc-integration-middleware` project [here](https://github.com/amplience/dc-integration-middleware/blob/main/docs/vendor/commerce/bigcommerce-cors.md)

--- a/docs/commerce/bigcommerce.md
+++ b/docs/commerce/bigcommerce.md
@@ -1,5 +1,7 @@
 # BigCommerce
 
+_NOTE: This backend does not support CORS requests - it is only available when using the middleware API. An alternate vendor [`bigcommerce-cors`](./bigcommerce-cors.md) is available that uses the Storefront GraphQL API to support product and category requests._
+
 In order to have this extension point to your BigCommerce instance you need specific installation params, instance details and API access. 
 
 [Extension Instalation Params Docs](https://amplience.com/developers/docs/integrations/extensions/register-use/#installation-parameters)

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,29 @@
+# Codec Errors
+
+## Authentication Error
+
+`AuthUnreachable`, `AuthError`, `NotAuthenticated`
+
+Authentication errors generally mean that authentication parameters, such as client id/secret, token, or even the API url may be incorrect. See the [middleware project's documentation](https://github.com/amplience/dc-integration-middleware/tree/main/docs/vendor/commerce) for information on properly setting up each type of vendor.
+
+## API Error
+
+`ApiError`, `ApiGraphQL`
+
+API errors may indicate a misconfiguration on either the vendor side or the extension params. The error status code and message may give some hint as to what the problem is. It's also possible that they represent a bug in the toolkit or integration middleware, in which case they should be reported via an issue.
+
+## Cors
+
+The ecomm-toolkit extension runs from within the browser, so it is subject to Cross Origin request restrictions imposed by the browser. These mean that requests outside the same domain must be explicitly allowed by the destination, in our case the vendor.
+
+The vendor must explicitly allow the domain the extension is running on - this is usually configurable via an admin control panel. When a CORS error is displayed, the origin you should add to your vendor's "allowed origins" list should be printed out. More information on CORS setup is available for each vendor in the [middleware project's documentation](https://github.com/amplience/dc-integration-middleware/tree/main/docs/vendor/commerce).
+
+For some vendors, some types of resource don't have any way of accessing them via CORS at all. View the [middleware support table](https://github.com/amplience/dc-integration-middleware/blob/main/README.md) for more information.
+
+## Not Supported
+
+Certain vendors don't support all request types. Verify that your vendor supports the required requests using the [middleware support table](https://github.com/amplience/dc-integration-middleware/blob/main/README.md).
+
+## Other
+
+Make sure your vendor params are correct. If they are pointing to the wrong service, no service at all or your API client doesn't have appropriate permissions, unexpected errors may occur. 

--- a/lib/sdk.ts
+++ b/lib/sdk.ts
@@ -42,38 +42,32 @@ const amplienceSDK = async () => {
     let { instance, installation } = sdk.params as ExtParameters
     let commerceApi = await initCommerceApi(installation)
 
-    try {
-        if (instance.data === 'category') {
-            if (instance.view === 'tree') {
-                values = await commerceApi.getCategoryTree({})
-            }
-            else {
-                let categoryTree: any[] = await commerceApi.getCategoryTree({})
-                values = flattenCategories(categoryTree).map(cat => ({ name: `(${cat.slug}) ${cat.name}`, slug: cat.slug, id: cat.id }))
-
-                value = instance.type === 'string' && value ? 
-                    (instance.view === 'multi' ? 
-                        values.filter(opt => value.includes(opt.id)) : 
-                        values.find(opt => value.includes(opt.id))) :
-                    value
-            }
-        } else if (instance.data === 'product') {
+    if (instance.data === 'category') {
+        if (instance.view === 'tree') {
+            values = await commerceApi.getCategoryTree({})
+        }
+        else {
             let categoryTree: any[] = await commerceApi.getCategoryTree({})
             values = flattenCategories(categoryTree).map(cat => ({ name: `(${cat.slug}) ${cat.name}`, slug: cat.slug, id: cat.id }))
-            value = instance.type === 'string' && value ? values.find(opt => cleanValue(value) == opt.id) : value
-        }
-        else { // a.data === 'customerGroups'
-            values = await commerceApi.getCustomerGroups({})
+
             value = instance.type === 'string' && value ? 
                 (instance.view === 'multi' ? 
-                    values.filter(opt => value.includes(opt.id)) :
+                    values.filter(opt => value.includes(opt.id)) : 
                     values.find(opt => value.includes(opt.id))) :
                 value
         }
-    } catch (e) {
-        // TODO: show modal error
-        console.log("ERROR", e)
-
+    } else if (instance.data === 'product') {
+        let categoryTree: any[] = await commerceApi.getCategoryTree({})
+        values = flattenCategories(categoryTree).map(cat => ({ name: `(${cat.slug}) ${cat.name}`, slug: cat.slug, id: cat.id }))
+        value = instance.type === 'string' && value ? values.find(opt => cleanValue(value) == opt.id) : value
+    }
+    else { // a.data === 'customerGroups'
+        values = await commerceApi.getCustomerGroups({})
+        value = instance.type === 'string' && value ? 
+            (instance.view === 'multi' ? 
+                values.filter(opt => value.includes(opt.id)) :
+                values.find(opt => value.includes(opt.id))) :
+            value
     }
 
     let ampSDK = {

--- a/lib/sdk.ts
+++ b/lib/sdk.ts
@@ -42,32 +42,38 @@ const amplienceSDK = async () => {
     let { instance, installation } = sdk.params as ExtParameters
     let commerceApi = await initCommerceApi(installation)
 
-    if (instance.data === 'category') {
-        if (instance.view === 'tree') {
-            values = await commerceApi.getCategoryTree({})
-        }
-        else {
+    try {
+        if (instance.data === 'category') {
+            if (instance.view === 'tree') {
+                values = await commerceApi.getCategoryTree({})
+            }
+            else {
+                let categoryTree: any[] = await commerceApi.getCategoryTree({})
+                values = flattenCategories(categoryTree).map(cat => ({ name: `(${cat.slug}) ${cat.name}`, slug: cat.slug, id: cat.id }))
+
+                value = instance.type === 'string' && value ? 
+                    (instance.view === 'multi' ? 
+                        values.filter(opt => value.includes(opt.id)) : 
+                        values.find(opt => value.includes(opt.id))) :
+                    value
+            }
+        } else if (instance.data === 'product') {
             let categoryTree: any[] = await commerceApi.getCategoryTree({})
             values = flattenCategories(categoryTree).map(cat => ({ name: `(${cat.slug}) ${cat.name}`, slug: cat.slug, id: cat.id }))
-
+            value = instance.type === 'string' && value ? values.find(opt => cleanValue(value) == opt.id) : value
+        }
+        else { // a.data === 'customerGroups'
+            values = await commerceApi.getCustomerGroups({})
             value = instance.type === 'string' && value ? 
                 (instance.view === 'multi' ? 
-                    values.filter(opt => value.includes(opt.id)) : 
+                    values.filter(opt => value.includes(opt.id)) :
                     values.find(opt => value.includes(opt.id))) :
                 value
         }
-    } else if (instance.data === 'product') {
-        let categoryTree: any[] = await commerceApi.getCategoryTree({})
-        values = flattenCategories(categoryTree).map(cat => ({ name: `(${cat.slug}) ${cat.name}`, slug: cat.slug, id: cat.id }))
-        value = instance.type === 'string' && value ? values.find(opt => cleanValue(value) == opt.id) : value
-    }
-    else { // a.data === 'customerGroups'
-        values = await commerceApi.getCustomerGroups({})
-        value = instance.type === 'string' && value ? 
-            (instance.view === 'multi' ? 
-                values.filter(opt => value.includes(opt.id)) :
-                values.find(opt => value.includes(opt.id))) :
-            value
+    } catch (e) {
+        // TODO: show modal error
+        console.log("ERROR", e)
+
     }
 
     let ampSDK = {

--- a/lib/util/index.ts
+++ b/lib/util/index.ts
@@ -1,5 +1,6 @@
 import { Identifiable } from '@amplience/dc-integration-middleware'
 import { SFCCTreeItemData } from "../models/treeItemData";
+import { CodecErrorType } from '@amplience/dc-integration-middleware';
 export module Utils {
 
     export function flatten (node: any, key = 'categories') : Identifiable[]  {
@@ -62,5 +63,22 @@ export module Utils {
             arr.push({name: array[i].id, id: array[i].id});
         }
         return arr;
+    }
+
+    export function errorToString(e: any) {
+        if (e.type) {
+            switch (e.type) {
+                case CodecErrorType.Cors:
+                    return `Cross-Origin Request Blocked. Make sure that you have properly configured your vendor to accept requests from ${window.location.origin}.`
+                case CodecErrorType.NotAuthenticated:
+                    return `Authentication error, make sure your authentication params are properly configured.\n\n${e.message}`
+                case CodecErrorType.ApiError:
+                    return `API Error, make sure your params are properly configured.\n\n${e.message}`
+            }
+
+            return e.message;
+        } else {
+            return e.toString();
+        }
     }
 }

--- a/lib/util/index.ts
+++ b/lib/util/index.ts
@@ -66,17 +66,24 @@ export module Utils {
     }
 
     export function errorToString(e: any) {
+        const docsUrl = 'https://github.com/amplience/dc-extension-ecomm-toolkit/blob/main/docs/errors.md'
+
         if (e.type) {
             switch (e.type) {
                 case CodecErrorType.Cors:
-                    return `Cross-Origin Request Blocked. Make sure that you have properly configured your vendor to accept requests from ${window.location.origin}.`
+                    return `Cross-Origin Request Blocked. Make sure that you have properly configured your vendor to accept requests from ${window.location.origin}.\n\nSee ${docsUrl}#cors for more information.`
                 case CodecErrorType.NotAuthenticated:
-                    return `Authentication error, make sure your authentication params are properly configured.\n\n${e.message}`
+                case CodecErrorType.AuthError:
+                case CodecErrorType.AuthUnreachable:
+                    return `Authentication error, make sure your authentication params are properly configured.\n\nSee ${docsUrl}#authentication-error for more information.\n\n${e.message}`
                 case CodecErrorType.ApiError:
-                    return `API Error, make sure your params are properly configured.\n\n${e.message}`
+                case CodecErrorType.ApiGraphQL:
+                    return `API Error, make sure your params are properly configured.\n\nSee ${docsUrl}#api-error for more information.\n\n${e.message}`
+                case CodecErrorType.NotSupported:
+                    return `Method not supported by vendor.\n\nSee ${docsUrl}#not-supported for more information.\n\n${e.message}`
             }
 
-            return e.message;
+            return `Encountered error '${CodecErrorType[e.type]}'. See ${docsUrl}#other for more information.\n\n${e.message}`;
         } else {
             return e.toString();
         }

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,9 @@ module.exports = {
   images: {
     unoptimized: true
   },
+  env: {
+    INTEGRATION_MIDDLEWARE_SERVER: process.env.INTEGRATION_MIDDLEWARE_SERVER
+  },
   webpack: (config, { isServer }) => {
     if (!isServer) {
       return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "@amplience/dc-extension-ecomm-toolkit",
             "version": "1.4.0",
             "dependencies": {
-                "@amplience/dc-integration-middleware": "git+https://github.com/amplience/dc-integration-middleware.git#v2.0.0",
+                "@amplience/dc-integration-middleware": "github:amplience/dc-integration-middleware#v2.0.0",
                 "@emotion/react": "^11.9.0",
                 "@emotion/styled": "^11.8.1",
                 "@mui/icons-material": "^5.6.0",
@@ -36,8 +36,8 @@
             }
         },
         "node_modules/@amplience/dc-integration-middleware": {
-            "version": "1.1.0",
-            "resolved": "git+ssh://git@github.com/amplience/dc-integration-middleware.git#71fa40e34450962bb4fed2badfe0d03e507a9d34",
+            "version": "2.0.0",
+            "resolved": "git+ssh://git@github.com/amplience/dc-integration-middleware.git#ac5870db11973e8867fae786fb6a7139c108d265",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "^0.27.2",
@@ -8732,7 +8732,7 @@
     },
     "dependencies": {
         "@amplience/dc-integration-middleware": {
-            "version": "git+ssh://git@github.com/amplience/dc-integration-middleware.git#71fa40e34450962bb4fed2badfe0d03e507a9d34",
+            "version": "git+ssh://git@github.com/amplience/dc-integration-middleware.git#ac5870db11973e8867fae786fb6a7139c108d265",
             "from": "@amplience/dc-integration-middleware@git+https://github.com/amplience/dc-integration-middleware.git#v2.0.0",
             "requires": {
                 "axios": "^0.27.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "@amplience/dc-extension-ecomm-toolkit",
             "version": "1.4.0",
             "dependencies": {
-                "@amplience/dc-integration-middleware": "git+https://github.com/amplience/dc-integration-middleware.git#v1.1.0",
+                "@amplience/dc-integration-middleware": "git+https://github.com/amplience/dc-integration-middleware.git#v2.0.0",
                 "@emotion/react": "^11.9.0",
                 "@emotion/styled": "^11.8.1",
                 "@mui/icons-material": "^5.6.0",
@@ -8733,7 +8733,7 @@
     "dependencies": {
         "@amplience/dc-integration-middleware": {
             "version": "git+ssh://git@github.com/amplience/dc-integration-middleware.git#71fa40e34450962bb4fed2badfe0d03e507a9d34",
-            "from": "@amplience/dc-integration-middleware@git+https://github.com/amplience/dc-integration-middleware.git#v1.1.0",
+            "from": "@amplience/dc-integration-middleware@git+https://github.com/amplience/dc-integration-middleware.git#v2.0.0",
             "requires": {
                 "axios": "^0.27.2",
                 "btoa": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "prepare-major-release": "run-s build version:major"
     },
     "dependencies": {
-        "@amplience/dc-integration-middleware": "git+https://github.com/amplience/dc-integration-middleware.git#v2.0.0",
+        "@amplience/dc-integration-middleware": "github:amplience/dc-integration-middleware#v2.0.0",
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
         "@mui/icons-material": "^5.6.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "prepare-major-release": "run-s build version:major"
     },
     "dependencies": {
-        "@amplience/dc-integration-middleware": "git+https://github.com/amplience/dc-integration-middleware.git#v1.1.0",
+        "@amplience/dc-integration-middleware": "git+https://github.com/amplience/dc-integration-middleware.git#v2.0.0",
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
         "@mui/icons-material": "^5.6.0",


### PR DESCRIPTION
This PR should update dc-integration-middleware with a version that uses CORS requests by default instead of the middleware API. This should be more reliable, and means that we don't have to officially host a middleware API.

The middleware API and CORS blocked requests are still available via two methods:
- `INTEGRATION_MIDDLEWARE_SERVER` set as `1` when build/run this project to host the API along with the extension.
  - The extension being hosted will try to use the middleware by default, and the 
- Passing a custom URL in `middleware_api` in the extension parameters.

This also fixes a bug with the page cache where some APIs would not properly make product requests.

TODO:
- dc-integration-middleware version bump (https://github.com/amplience/dc-integration-middleware/pull/3 after it releases)
  - You can test current functionality by installing the dc-integration-middleware package from a local copy of the repo (after running `npm run build`)