### PR TITLE
chore: update middleware to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "@amplience/dc-extension-ecomm-toolkit",
             "version": "1.4.0",
             "dependencies": {
-                "@amplience/dc-integration-middleware": "github:amplience/dc-integration-middleware#v2.0.0",
+                "@amplience/dc-integration-middleware": "github:amplience/dc-integration-middleware#v2.0.1",
                 "@emotion/react": "^11.9.0",
                 "@emotion/styled": "^11.8.1",
                 "@mui/icons-material": "^5.6.0",
@@ -36,8 +36,8 @@
             }
         },
         "node_modules/@amplience/dc-integration-middleware": {
-            "version": "2.0.0",
-            "resolved": "git+ssh://git@github.com/amplience/dc-integration-middleware.git#ac5870db11973e8867fae786fb6a7139c108d265",
+            "version": "2.0.1",
+            "resolved": "git+ssh://git@github.com/amplience/dc-integration-middleware.git#a5f2c4a1fcd79602030fd08fa6842217d5ff5417",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "^0.27.2",
@@ -6947,9 +6947,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.11.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
-            "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
+            "version": "6.11.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+            "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
             "dependencies": {
                 "side-channel": "^1.0.4"
             },
@@ -8732,8 +8732,8 @@
     },
     "dependencies": {
         "@amplience/dc-integration-middleware": {
-            "version": "git+ssh://git@github.com/amplience/dc-integration-middleware.git#ac5870db11973e8867fae786fb6a7139c108d265",
-            "from": "@amplience/dc-integration-middleware@git+https://github.com/amplience/dc-integration-middleware.git#v2.0.0",
+            "version": "git+ssh://git@github.com/amplience/dc-integration-middleware.git#a5f2c4a1fcd79602030fd08fa6842217d5ff5417",
+            "from": "@amplience/dc-integration-middleware@git+https://github.com/amplience/dc-integration-middleware.git#v2.0.1",
             "requires": {
                 "axios": "^0.27.2",
                 "btoa": "^1.2.1",
@@ -13820,9 +13820,9 @@
             "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
         },
         "qs": {
-            "version": "6.11.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
-            "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
+            "version": "6.11.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+            "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
             "requires": {
                 "side-channel": "^1.0.4"
             }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "prepare-major-release": "run-s build version:major"
     },
     "dependencies": {
-        "@amplience/dc-integration-middleware": "github:amplience/dc-integration-middleware#v2.0.0",
+        "@amplience/dc-integration-middleware": "github:amplience/dc-integration-middleware#v2.0.1",
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
         "@mui/icons-material": "^5.6.0",


### PR DESCRIPTION
Updates middleware to 2.0.1 to avoid a CORS issue when using the middleware API.